### PR TITLE
Prevent errors on activesupport 2.3

### DIFF
--- a/lib/test/unit/active_support.rb
+++ b/lib/test/unit/active_support.rb
@@ -23,8 +23,8 @@ require "active_support/testing/setup_and_teardown"
 
 module ActiveSupport::Testing::SetupAndTeardown
   module ClassMethods
-    remove_method :setup
-    remove_method :teardown
+    remove_method :setup if method_defined? :setup
+    remove_method :teardown if method_defined? :teardown
   end
 
   if const_defined?(:ForClassicTestUnit)


### PR DESCRIPTION
```
method `setup' not defined in ActiveSupport::Testing::SetupAndTeardown::ClassMethods
```
