### PR TITLE
include ActiveSupport::Testing::Assertions

### DIFF
--- a/lib/test/unit/active_support.rb
+++ b/lib/test/unit/active_support.rb
@@ -18,10 +18,13 @@
 
 require "test-unit"
 require "test/unit/assertion-failed-error"
+require 'active_support/testing/assertions'
 
 module ActiveSupport
   remove_const :TestCase
   class TestCase < ::Test::Unit::TestCase
+    include ActiveSupport::Testing::Assertions
+
     Assertion = ::Test::Unit::AssertionFailedError
   end
 end


### PR DESCRIPTION
We cat't use the following assertion methods.

- ActiveSupport::Testing.assert_not
- ActiveSupport::Testing.assert_difference
- ActiveSupport::Testing.assert_no_difference

This patch make those assertion methods usable.