### PR TITLE
Prevent active_support/test_case.rb from being required

### DIFF
--- a/lib/test/unit/active_support.rb
+++ b/lib/test/unit/active_support.rb
@@ -17,6 +17,13 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 require "test-unit"
+# Prevent AS/test_case.rb from being required after this
+unless $LOADED_FEATURES.any? {|lf| lf.end_with? "active_support/test_case.rb"}
+  $LOAD_PATH.reverse_each do |lp|
+    path = File.join(lp, "active_support/test_case.rb")
+    $LOADED_FEATURES << path if File.exist?(path)
+  end
+end
 require "active_support/testing/assertions"
 
 module ActiveSupport


### PR DESCRIPTION
Here's an attempt to solve https://github.com/test-unit/test-unit-rails/issues/4

Current version of test-unit-rails is not capable of testing test/mailers because action_mailer/test_case.rb [explicitly requires active_support/test_case.rb at the very top](https://github.com/rails/rails/blob/53265e88067084855753522256b86568fdad5b0c/actionmailer/lib/action_mailer/test_case.rb#L1), which causes "superclass mismatch for class TestCase (TypeError)".

This happens because AS tries to define `AS::TestCase` class inheriting `::Minitest::Test` while our definition of `AS::TestCase` inheriting `::Test::Unit::TestCase` has already been done here.

This patch squeezes AS/test_case.rb into `$LOADED_FEATURES` so that the actual AS/test_case.rb will never be loaded.
I know this code is dirty and imperfect, but I believe dirty code that works must be better than no code in any way.