### PR TITLE
add monkeypatched constant and methods

### DIFF
--- a/lib/test/unit/active_support.rb
+++ b/lib/test/unit/active_support.rb
@@ -38,6 +38,18 @@ module ActiveSupport
   class TestCase < ::Test::Unit::TestCase
     include ActiveSupport::Testing::Assertions
 
+    # shoulda needs ActiveSupport::TestCase::Assertion, which is not set in test-unit 3
+    Assertion = Test::Unit::AssertionFailedError
+
+    # rails 4.1 (action dispatch assertions) needs the 'message' method which is not defined in test-unit 3
+    def message msg = nil, ending = nil, &default
+      proc {
+        msg = msg.call.chomp(".") if Proc === msg
+        custom_message = "#{msg}.\n" unless msg.nil? or msg.to_s.empty?
+        "#{custom_message}#{default.call}#{ending || "."}"
+      }
+    end
+
     private
     def mu_pp(object)
       AssertionMessage.convert(object)

--- a/test/test_assertions.rb
+++ b/test/test_assertions.rb
@@ -31,4 +31,12 @@ class TestAssertions < ActiveSupport::TestCase
     assert_no_difference("x") do
     end
   end
+
+  test "message method" do
+    proc = self.message("test","bernd") do
+      "hans"
+    end
+
+    assert_equal "test.\nhansbernd", proc.call
+  end
 end


### PR DESCRIPTION
thereby increasing compatibility with rails 4.1

As the comments say, we had problems with test-unit-activesupport and rails 4.1. The routing helpers did not work because the `message` method was missing in the monkeyptached TestCase. Sadly, this seems very hard to test in a clean way.

Also, we are using shoulda-matchers which requires the constant `ActiveSupport::TestCase::Assertion` which is again is missing in the monkeypatched TestCase.

Both are present in the original `ActiveSupport::TestCase` from `activesupport 4.1.14.2` .