### PR TITLE
Active Support < 5 doesn't have file_fixtures

### DIFF
--- a/lib/test/unit/active_support.rb
+++ b/lib/test/unit/active_support.rb
@@ -20,7 +20,11 @@ require "test-unit"
 require "active_support"
 require 'active_support/core_ext/class/attribute'
 require "active_support/testing/assertions"
-require 'active_support/testing/file_fixtures'
+begin
+  require 'active_support/testing/file_fixtures'
+rescue LoadError
+  # Active Support < 5 doesn't have file_fixtures
+end
 
 as_test_case_name = "active_support/test_case.rb"
 unless $LOADED_FEATURES.any? {|feature| feature.end_with?(as_test_case_name)}
@@ -42,7 +46,7 @@ module ActiveSupport
 
   class TestCase < ::Test::Unit::TestCase
     include ActiveSupport::Testing::Assertions
-    include ActiveSupport::Testing::FileFixtures
+    include ActiveSupport::Testing::FileFixtures if defined?(ActiveSupport::Testing::FileFixtures)
 
     # shoulda needs ActiveSupport::TestCase::Assertion, which is not
     # set in test-unit 3


### PR DESCRIPTION
test-unit-activesupport stopped working since ff44402db541b3cc0decde52dd9f94fdfbad290c.

I couldn't find any document or comment mentioning supported versions, but it's very much surprising if you meant to drop Rails 4 support in between 1.0.7 and 1.0.8.
I mean, I don't believe it was intentional, so here's a fix.