### PR TITLE
Prevent NameError on activesupport >= 6.1

### DIFF
--- a/lib/test/unit/active_support.rb
+++ b/lib/test/unit/active_support.rb
@@ -21,8 +21,11 @@ require "active_support"
 require 'active_support/core_ext/class/attribute'
 require "active_support/testing/assertions"
 begin
+  require "minitest"
   require 'active_support/testing/file_fixtures'
+  require 'active_support/testing/tagged_logging'
 rescue LoadError
+  # Active Support < 4 doesn't have minitest, tagged_logging
   # Active Support < 5 doesn't have file_fixtures
 end
 
@@ -47,6 +50,7 @@ module ActiveSupport
   class TestCase < ::Test::Unit::TestCase
     include ActiveSupport::Testing::Assertions
     include ActiveSupport::Testing::FileFixtures if defined?(ActiveSupport::Testing::FileFixtures)
+    include ActiveSupport::Testing::TaggedLogging if defined?(ActiveSupport::Testing::TaggedLogging)
 
     # shoulda needs ActiveSupport::TestCase::Assertion, which is not
     # set in test-unit 3

--- a/test/test_assertions.rb
+++ b/test/test_assertions.rb
@@ -39,4 +39,15 @@ class TestAssertions < ActiveSupport::TestCase
 
     assert_equal("test.\nhansbernd", delayed_message.call)
   end
+
+  if ActiveSupport.version >= Gem::Version.new("6.1.0")
+    test "unexpected error" do
+      assert_raise(Minitest::UnexpectedError) do
+        x = 1
+        assert_difference("x") do
+          raise
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
When unexpeced exceptions are raised in test case, ActiveSupport::Testing::Assertions use:

- `Minitest::UnexpectedError` (AS >= 6.1)
    - https://github.com/rails/rails/blob/v6.1.0/activesupport/lib/active_support/testing/assertions.rb#L36
- `tagged_logger` (AS >= 7.0)
    - https://github.com/rails/rails/blob/v7.0.0/activesupport/lib/active_support/testing/assertions.rb#L252

---

### reproduction code

```rb
require "test/unit/active_support"

class TestAssertions < ActiveSupport::TestCase
  test "unexpected error" do
    x = 1
    assert_difference("x") { raise }
  end
end
```

no `require "minitest"`:
```
Error: test: unexpected error(TestAssertions): NameError: uninitialized constant ActiveSupport::Testing::Assertions::Minitest
/usr/local/bundle/gems/activesupport-7.0.2.2/lib/active_support/testing/assertions.rb:251:in `rescue in _assert_nothing_raised_or_warn'
/usr/local/bundle/gems/activesupport-7.0.2.2/lib/active_support/testing/assertions.rb:249:in `_assert_nothing_raised_or_warn'
/usr/local/bundle/gems/activesupport-7.0.2.2/lib/active_support/testing/assertions.rb:102:in `assert_difference'
test.rb:7:in `block in <class:TestAssertions>'
```

no `include ActiveSupport::Testing::TaggedLogging`:
```
Error: test: unexpected error(TestAssertions): NameError: undefined local variable or method `tagged_logger' for #<TestAssertions:0x00005641cf790f88 @method_name="test: unexpected error", ...(snip)... >
/usr/local/bundle/gems/activesupport-7.0.2.2/lib/active_support/testing/assertions.rb:252:in `rescue in _assert_nothing_raised_or_warn'
/usr/local/bundle/gems/activesupport-7.0.2.2/lib/active_support/testing/assertions.rb:249:in `_assert_nothing_raised_or_warn'
/usr/local/bundle/gems/activesupport-7.0.2.2/lib/active_support/testing/assertions.rb:102:in `assert_difference'
test.rb:7:in `block in <class:TestAssertions>'
