### PR TITLE
Bring back Ruby < 2.3 compatibility

### DIFF
--- a/lib/test/unit/active_support.rb
+++ b/lib/test/unit/active_support.rb
@@ -92,7 +92,7 @@ module ActiveSupport
         assert_nothing_raised(&block)
       rescue Test::Unit::AssertionFailedError => e
         if tagged_logger && tagged_logger.warn?
-          warning = <<~MSG
+          warning = <<-MSG.gsub(/^\s+/, "")
             #{self.class} - #{name}: #{e.error.class} raised.
             If you expected this exception, use `assert_raise` as near to the code that raises as possible.
             Other block based assertions (e.g. `#{assertion}`) can be used, as long as `assert_raise` is inside their block.


### PR DESCRIPTION
I noticed that 1195347f9419c327cf4045a16da193c3f9d20f97 broke Ruby < 2.3 compatibility by introducing `<<~` operator. And so here's a patch that brings old Rubies support back.

I'm not asking you, the maintainers of this software, to keep supporting EOLed versions of Ruby forever on your side. I'm not asking you not to use new Ruby features.

But as a test-unit user who still runs Ruby 2.2 on CI, I can send a whack-a-mole fix like this one if I detect something that doesn't work for me. So I'm just asking you to "allow me to send a patch for unsupported versions of Ruby". Either way, you need not to claim that you're supporting Ruby 2.2.

You can just close this PR if you don't like the direction. I'll not complain.

But having this merged would remove my workarounds on my side, https://github.com/kaminari/kaminari/commit/c6c0c58faf19cba0d4fac74de146e7823be1c0fa https://github.com/kaminari/kaminari/commit/a9dda8d918603fb2247d6e3af68493e1a00ba1f3 and probably save some (not so many) other users who are in the same situation.