### PR TITLE
CI against Ruby 3.2 and 3.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: "Ruby 3.3 & Active Support 7"
+            ruby-version: "3.3"
+            activesupport-version: "7"
+          - name: "Ruby 3.2 & Active Support 7"
+            ruby-version: "3.2"
+            activesupport-version: "7"
           - name: "Ruby 3.1 & Active Support 7"
             ruby-version: "3.1"
             activesupport-version: "7"


### PR DESCRIPTION
This patch adds Ruby 3.2 and 3.3 to the test matrix.